### PR TITLE
Move to unique

### DIFF
--- a/lib/fluent/plugin/in_cat_sweep.rb
+++ b/lib/fluent/plugin/in_cat_sweep.rb
@@ -112,12 +112,12 @@ module Fluent
     def get_processing_filename(filename)
       tmpfile = String.new
       tmpfile << filename << '.' << Process.pid.to_s << '.'
-      tmpfile << Time.now.to_i.to_s << '.' << @processing_file_suffix
+      tmpfile << Time.now.to_i.to_s << @processing_file_suffix
     end
 
     def get_error_filename(filename)
       errfile = String.new
-      errfile << filename << '.' << @error_file_suffix
+      errfile << filename << @error_file_suffix
     end
 
     def safe_fail(filename)

--- a/test/test_in_cat_sweep.rb
+++ b/test/test_in_cat_sweep.rb
@@ -117,11 +117,11 @@ class CatSweepInputTest < Test::Unit::TestCase
 
     assert(Dir.glob("#{TMP_DIR_FROM}/test_move_file*").empty?)
     assert_match(
-      %r{\A#{TMP_DIR_TO}/test_move_file.*\.processing},
-      Dir.glob("#{TMP_DIR_TO}/test_move_file*").first)
+      %r{\A#{TMP_DIR_TO}#{TMP_DIR_FROM}/test_move_file},
+      Dir.glob("#{TMP_DIR_TO}#{TMP_DIR_FROM}/test_move_file*").first)
     assert_equal(
       test_cases.map{|t|t['msg']}.join.to_s,
-      File.read(Dir.glob("#{TMP_DIR_TO}/test_move_file*").first))
+      File.read(Dir.glob("#{TMP_DIR_TO}#{TMP_DIR_FROM}/test_move_file*").first))
   end
 
   def test_oneline_max_bytes


### PR DESCRIPTION
This PR essentially includes 3 things:
1. Avoid suffix to be ..processing and ..error (fix to be .processing and .error)
2. Create directories on move_to so that filenames will be unique, otherwise, some files would be overwritten
   - Also revert processing_filename on move_to
3. Add error class name to error_filename suffix so that we can tell what errors occurred easily
