### PR TITLE
Add file_event_stream option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ Our assumption is that this mechanism should provide more durability than `in_ta
 
   # Optional. default 5 seconds.
   run_interval 10
+
+  # Optional. Emit entire file contents as an event, default emits each line as an event.
+  # This assures that fluentd emits the entire file contents together. Please note that buffer_chunk_limit
+  # must be larger than bytes in a file to be sent by buffered output plugins such as out_forward, out_s3.
+  file_event_stream false
 </source>
 ```
 


### PR DESCRIPTION
Just an idea. This option assures that fluentd emits the entire file contents together. 

Previously, when we get errors in buffered output plugin, it was not easy to find which lines to lines in a log file must be re-sent manually. But, with this option, we can simply re-send an entire log file to recover. 
