### PR TITLE
Add test and fix bug with empty line in file with 0.12.29 fluentd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ rvm:
   - 2.2.*
 gemfile:
   - gemfiles/Gemfile.fluentd.0.12
+  - gemfiles/Gemfile.fluentd.0.12.29
   - gemfiles/Gemfile.fluentd.0.10
   - gemfiles/Gemfile.fluentd.0.10.45

--- a/gemfiles/Gemfile.fluentd.0.12.29
+++ b/gemfiles/Gemfile.fluentd.0.12.29
@@ -1,0 +1,4 @@
+source "http://rubygems.org"
+
+gem 'fluentd', '= 0.12.29'
+gemspec :path => "../"

--- a/lib/fluent/plugin/in_cat_sweep.rb
+++ b/lib/fluent/plugin/in_cat_sweep.rb
@@ -237,7 +237,7 @@ module Fluent
     end
 
     def emit_line(line)
-      if line
+      if line && line.length > 0
         time, record = parse_line(line)
         if time and record
           router.emit(@tag, time, record)
@@ -248,7 +248,7 @@ module Fluent
     def emit_file(fp)
       entries = []
       read_each_line(fp) do |line|
-        if line
+        if line && line.length > 0
           entry = parse_line(line)
           entries << entry if entry
         end

--- a/test/test_in_cat_sweep.rb
+++ b/test/test_in_cat_sweep.rb
@@ -94,6 +94,7 @@ class CatSweepInputTest < Test::Unit::TestCase
       'json' => [
         {'msg' => {'k' => 123, 'message' => 'tcptest1'}.to_json + "\n", 'expected' => 'tcptest1'},
         {'msg' => {'k' => 'tcptest2', 'message' => 456}.to_json + "\n", 'expected' => 456},
+        {'msg' => "\n", 'expected' => ''},
       ]
     }
 


### PR DESCRIPTION
Currently in 0.12.29 fluentd there is an issue with blank lines that generates the following:

```
2017-03-27 18:59:36 +0000 [error]: in_cat_sweep: processing: /tmp/test/10.json.28621.1490641176.processing error=#<NoMethodError: undefined method `delete' for nil:NilClass> error_class=NoMethodError
  2017-03-27 18:59:36 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.29/lib/fluent/parser.rb:275:in `parse'
  2017-03-27 18:59:36 +0000 [error]: /etc/td-agent/plugin/in_cat_sweep.rb:264:in `parse_line'
  2017-03-27 18:59:36 +0000 [error]: /etc/td-agent/plugin/in_cat_sweep.rb:241:in `emit_line'
  2017-03-27 18:59:36 +0000 [error]: /etc/td-agent/plugin/in_cat_sweep.rb:283:in `block (2 levels) in process'
  2017-03-27 18:59:36 +0000 [error]: /etc/td-agent/plugin/in_cat_sweep.rb:231:in `block in read_each_line'
  2017-03-27 18:59:36 +0000 [error]: /etc/td-agent/plugin/in_cat_sweep.rb:218:in `each'
  2017-03-27 18:59:36 +0000 [error]: /etc/td-agent/plugin/in_cat_sweep.rb:218:in `read_each_line'
  2017-03-27 18:59:36 +0000 [error]: /etc/td-agent/plugin/in_cat_sweep.rb:282:in `block in process'
  2017-03-27 18:59:36 +0000 [error]: /etc/td-agent/plugin/in_cat_sweep.rb:278:in `open'
  2017-03-27 18:59:36 +0000 [error]: /etc/td-agent/plugin/in_cat_sweep.rb:278:in `process'
  2017-03-27 18:59:36 +0000 [error]: /etc/td-agent/plugin/in_cat_sweep.rb:95:in `block (2 levels) in run_periodic'
  2017-03-27 18:59:36 +0000 [error]: /etc/td-agent/plugin/in_cat_sweep.rb:295:in `lock_with_renaming'
  2017-03-27 18:59:36 +0000 [error]: /etc/td-agent/plugin/in_cat_sweep.rb:94:in `block in run_periodic'
  2017-03-27 18:59:36 +0000 [error]: /etc/td-agent/plugin/in_cat_sweep.rb:89:in `map'
  2017-03-27 18:59:36 +0000 [error]: /etc/td-agent/plugin/in_cat_sweep.rb:89:in `run_periodic'
```

This adds a test for this failure and a fix.