### PR TITLE
Tweak for v0.14 compat layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - '2.3'
   - '2.4'
 gemfile:
+  - gemfiles/Gemfile.fluentd.0.14
   - gemfiles/Gemfile.fluentd.0.12
   - gemfiles/Gemfile.fluentd.0.10
   - gemfiles/Gemfile.fluentd.0.10.45

--- a/gemfiles/Gemfile.fluentd.0.14
+++ b/gemfiles/Gemfile.fluentd.0.14
@@ -1,0 +1,4 @@
+source "http://rubygems.org"
+
+gem 'fluentd', '~> 0.14.0'
+gemspec :path => "../"

--- a/lib/fluent/plugin/in_cat_sweep.rb
+++ b/lib/fluent/plugin/in_cat_sweep.rb
@@ -1,3 +1,4 @@
+require 'fluent/input'
 
 module Fluent
   class CatSweepInput < Input

--- a/test/test_in_cat_sweep.rb
+++ b/test/test_in_cat_sweep.rb
@@ -24,7 +24,8 @@ class CatSweepInputTest < Test::Unit::TestCase
   ]
 
   CONFIG_MINIMUM_REQUIRED =
-    if current_fluent_version < fluent_version('0.12.0')
+    if current_fluent_version < fluent_version('0.12.0') ||
+       current_fluent_version >= fluent_version('0.14.0')
       CONFIG_BASE + %[
         format tsv
         keys ""


### PR DESCRIPTION
Requiring `fluent/input` explicitly is needed to work with Fluentd v0.14.
And I added some test fixes for v0.14.