### PR TITLE
Add `flock_with_rw_mode` option for doing flock on NFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ tmp/test
   # This assures that fluentd emits the entire file contents together. Please note that buffer_chunk_limit
   # must be larger than bytes in a file to be sent by buffered output plugins such as out_forward, out_s3.
   file_event_stream false
+
+  # Optional. When doing flock files, open these files with "r+" mode if this option is true, nor with "r" mode.
+  # default is false.
+  flock_with_rw_mode false
 </source>
 ```
 

--- a/lib/fluent/plugin/in_cat_sweep.rb
+++ b/lib/fluent/plugin/in_cat_sweep.rb
@@ -289,7 +289,7 @@ module Fluent
     end
 
     def lock_with_renaming(filename_from, filename_to)
-      file = File.open(filename_from)
+      file = File.open(filename_from, "r+")
       begin
         if file.flock(File::LOCK_EX | File::LOCK_NB)
           File.rename(filename_from, filename_to)

--- a/lib/fluent/plugin/in_cat_sweep.rb
+++ b/lib/fluent/plugin/in_cat_sweep.rb
@@ -22,6 +22,7 @@ module Fluent
     config_param :remove_after_processing, :bool,    :default => false
     config_param :run_interval,            :time,    :default => 5
     config_param :file_event_stream,       :bool,    :default => false
+    config_param :flock_with_rw_mode,      :bool,    :default => false
 
     # To support log_level option implemented by Fluentd v0.10.43
     unless method_defined?(:log)
@@ -288,8 +289,13 @@ module Fluent
       end
     end
 
+    def open_mode_for_flock
+      # When doing flock files on NFS, these files must be opend with writable mode.
+      @open_mode_for_flock ||= @flock_with_rw_mode ? "r+" : "r"
+    end
+
     def lock_with_renaming(filename_from, filename_to)
-      file = File.open(filename_from, "r+")
+      file = File.open(filename_from, open_mode_for_flock)
       begin
         if file.flock(File::LOCK_EX | File::LOCK_NB)
           File.rename(filename_from, filename_to)


### PR DESCRIPTION
When doing flock files on NFS, these files must be opend with writable mode. So `flock_with_rw_mode` option is added.

ref. http://man7.org/linux/man-pages/man2/flock.2.html