### PR TITLE
Ship v0.2.0

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: civitaspo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.2.0
+
+Breaking Changes:
+
+* Use v1.0 API.
+  * Drop support for Fluentd versions smaller than v0.14.
+  * https://github.com/civitaspo/fluent-plugin-cat-sweep/pull/21  ( by @karupanerura )
+
 # 0.1.5
 
 Enhancements:

--- a/README.md
+++ b/README.md
@@ -111,14 +111,21 @@ tmp/test
 
 ```
 <source>
-  type cat_sweep
+  @type cat_sweep
 
   # Required. process files that match this pattern using glob.
   file_path_with_glob /tmp/test/file_*
 
-  # Input pattern. It depends on Parser plugin
-  format tsv
-  keys xpath,access_time,label,payload
+  # Parser Plugin Setting
+  # You can use the old style instead. (Not recommended)
+  # ===
+  # format tsv
+  # keys xpath,access_time,label,payload
+  # ===
+  <parse>
+    @type tsv
+    keys xpath,access_time,label,payload
+  </parse>
 
   # Required. process files that are older than this parameter(seconds).
   # [WARNING!!]: this plugin moves or removes files even if the files are still open.

--- a/fluent-plugin-cat-sweep.gemspec
+++ b/fluent-plugin-cat-sweep.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-cat-sweep"
-  spec.version       = "0.1.5"
+  spec.version       = "0.2.0"
   spec.authors       = ["Civitaspo(takahiro.nakayama)", "Naotoshi Seo"]
   spec.email         = ["civitaspo@gmail.com", "sonots@gmail.com"]
 


### PR DESCRIPTION
# 0.2.0

Breaking Changes:

* Use v1.0 API.
  * Drop support for Fluentd versions smaller than v0.14.
  * https://github.com/civitaspo/fluent-plugin-cat-sweep/pull/21  ( by @karupanerura )